### PR TITLE
Fix schema addressCountry typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
           "@type": "City",
           "name": "Smyrna",
           "addressRegion": "GA",
-          "addressCountory": "US"
+          "addressCountry": "US"
         },
         {
           "@type": "City",


### PR DESCRIPTION
## Summary
- correct typo in index JSON-LD `areaServed` list (addressCountry)

## Testing
- `npx --yes -p htmlhint@latest htmlhint index.html` *(fails: tagname-lowercase errors in SVG elements)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d1f85efc8323819b7935bf7552e0