### PR TITLE
Link service cards and add nearby areas to Acworth page

### DIFF
--- a/automate-business-acworth-ga.html
+++ b/automate-business-acworth-ga.html
@@ -127,25 +127,25 @@
                 <div class="services-grid">
                     <div class="service-card">
                         <div class="service-icon">🏠</div>
-                        <h3>Lakefront HVAC Services</h3>
+                        <h3><a href="automate-hvac-business.html">Lakefront HVAC Services</a></h3>
                         <p>Managing HVAC systems for waterfront properties and seasonal homes requires flexible scheduling and specialized equipment tracking. Our automation handles both emergency calls and seasonal preparation services efficiently.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">⚡</div>
-                        <h3>Marine Electrical Systems</h3>
+                        <h3><a href="automate-electrical-business.html">Marine Electrical Systems</a></h3>
                         <p>From dock electrical installations to boat house wiring, Acworth electrical contractors need specialized project management for waterfront electrical work and seasonal property maintenance.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🔧</div>
-                        <h3>Lake Property Plumbing</h3>
+                        <h3><a href="automate-plumbing-business.html">Lake Property Plumbing</a></h3>
                         <p>Serving both permanent residents and seasonal property owners requires automated scheduling that accounts for property occupancy patterns and seasonal maintenance needs.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🏗️</div>
-                        <h3>Waterfront Construction</h3>
+                        <h3><a href="automate-contractor-business.html">Waterfront Construction</a></h3>
                         <p>Managing construction projects near water requires careful coordination and compliance tracking. Our automation helps manage permits, environmental requirements, and specialized contractor coordination.</p>
                     </div>
                 </div>
@@ -161,6 +161,15 @@
                 <p>Acworth's lake-centered economy creates natural seasonal variations in contractor demand. Spring brings dock and waterfront preparation work, summer increases emergency call volume from active properties, and fall involves seasonal shutdowns and winterization services. Our automation helps contractors plan capacity and manage cash flow through these predictable cycles.</p>
                 
                 <p>The growing popularity of Lake Allatoona as a recreational destination continues to drive property development and renovation projects, creating steady opportunities for contractors who can efficiently manage multiple project types and customer segments.</p>
+            </div>
+
+            <div class="content-section">
+                <h3>Nearby Service Areas</h3>
+                <ul>
+                    <li><a href="automate-business-kennesaw-ga.html">Kennesaw, GA</a></li>
+                    <li><a href="automate-business-marietta-ga.html">Marietta, GA</a></li>
+                    <li><a href="automate-business-woodstock-ga.html">Woodstock, GA</a></li>
+                </ul>
             </div>
 
             <div class="cta-section">


### PR DESCRIPTION
## Summary
- Link each Acworth service card heading to its detailed automation page.
- Add a Nearby Service Areas list linking to Kennesaw, Marietta, and Woodstock pages.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Fortress5-website/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b9d7217e7083239461dec11e3e67ae