### PR TITLE
Add service-card links and nearby cities section

### DIFF
--- a/automate-business-alpharetta-ga.html
+++ b/automate-business-alpharetta-ga.html
@@ -230,7 +230,35 @@
             color: #6b7280;
             font-size: 0.9rem;
         }
-        
+
+        .nearby-cities {
+            background: #f8fafc;
+            padding: 2rem;
+            border-radius: 1rem;
+            margin: 2rem 0;
+        }
+        .nearby-cities h3 {
+            font-size: 1.5rem;
+            font-weight: 600;
+            color: #1f2937;
+            margin-bottom: 1rem;
+        }
+        .nearby-cities ul {
+            list-style: none;
+            padding: 0;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+        }
+        .nearby-cities a {
+            color: #2563eb;
+            text-decoration: none;
+            font-weight: 500;
+        }
+        .nearby-cities a:hover {
+            text-decoration: underline;
+        }
+
         .cta-section {
             background: linear-gradient(135deg, #1f2937, #374151);
             color: white;
@@ -327,25 +355,25 @@
                 <div class="services-grid">
                     <div class="service-card">
                         <div class="service-icon">🏠</div>
-                        <h3>Luxury HVAC Systems</h3>
+                        <h3><a href="automate-hvac-business.html" style="color: inherit; text-decoration: none;">Luxury HVAC Systems</a></h3>
                         <p>Managing high-end HVAC installations and maintenance for luxury communities like Brookfield Country Club and Old Milton Parkway estates requires sophisticated scheduling systems to coordinate with homeowners' demanding schedules and premium service expectations.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">⚡</div>
-                        <h3>Commercial Electrical</h3>
+                        <h3><a href="automate-electrical-business.html" style="color: inherit; text-decoration: none;">Commercial Electrical</a></h3>
                         <p>Serving Alpharetta's technology corridor along Technology Parkway and North Point Parkway, electrical contractors need robust project management systems to handle complex commercial installations and corporate facility maintenance contracts.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🔧</div>
-                        <h3>Executive Plumbing Services</h3>
+                        <h3><a href="automate-plumbing-business.html" style="color: inherit; text-decoration: none;">Executive Plumbing Services</a></h3>
                         <p>From luxury residential developments near Avalon to executive office buildings in downtown Alpharetta, plumbing contractors require automated customer relationship management to maintain white-glove service standards and rapid response times.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🏗️</div>
-                        <h3>Premium Construction</h3>
+                        <h3><a href="automate-contractor-business.html" style="color: inherit; text-decoration: none;">Premium Construction</a></h3>
                         <p>Managing high-value construction projects throughout North Fulton County, from custom homes in Crabapple to commercial developments near North Point Mall, requires sophisticated project coordination and client communication automation.</p>
                     </div>
                 </div>
@@ -363,8 +391,16 @@
                 <p>As the "Technology City of the South," Alpharetta clients expect contractors to leverage advanced systems for project management, customer communication, and service delivery. The city's tech-forward business environment provides competitive advantages to contractors who embrace automation and digital business processes.</p>
                 
                 <p>North Fulton County's continued growth, anchored by developments like The Collection at Forsyth and ongoing commercial expansion along McGinnis Ferry Road, creates substantial opportunities for contractors who can efficiently scale operations while maintaining the premium service quality that defines successful businesses in Alpharetta's competitive marketplace.</p>
-                
+
                 <p>Automation enables Alpharetta contractors to manage larger client bases, coordinate complex project timelines, and maintain the consistent communication standards that build long-term relationships with the area's demanding but loyal customer base.</p>
+            </div>
+            <div class="nearby-cities">
+                <h3>Serving Nearby Cities</h3>
+                <ul>
+                    <li><a href="automate-business-roswell-ga.html">Roswell, GA</a></li>
+                    <li><a href="automate-business-johns-creek-ga.html">Johns Creek, GA</a></li>
+                    <li><a href="automate-business-sandy-springs-ga.html">Sandy Springs, GA</a></li>
+                </ul>
             </div>
 
             <div class="cta-section">

--- a/automate-business-dunwoody-ga.html
+++ b/automate-business-dunwoody-ga.html
@@ -327,25 +327,25 @@
                 <div class="services-grid">
                     <div class="service-card">
                         <div class="service-icon">❄️</div>
-                        <h3>Premium HVAC Services</h3>
+                        <h3><a href="automate-hvac-business.html" style="color: inherit; text-decoration: none;">Premium HVAC Services</a></h3>
                         <p>Serving Dunwoody's luxury homes from Georgetown to Dunwoody Village and managing commercial systems in Perimeter Center requires sophisticated scheduling and premium customer communication to meet high expectations.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">⚡</div>
-                        <h3>Electrical Contracting</h3>
+                        <h3><a href="automate-electrical-business.html" style="color: inherit; text-decoration: none;">Electrical Contracting</a></h3>
                         <p>Managing electrical projects across Dunwoody's diverse landscape, from smart home installations in Kingsley to complex commercial systems in Perimeter Mall area, demands efficient project coordination and client management.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🔧</div>
-                        <h3>Plumbing Operations</h3>
+                        <h3><a href="automate-plumbing-business.html" style="color: inherit; text-decoration: none;">Plumbing Operations</a></h3>
                         <p>Handling both emergency service calls in established neighborhoods like Dunwoody North and planned installations in new developments requires automated dispatch and premium customer service capabilities.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🏗️</div>
-                        <h3>Construction Management</h3>
+                        <h3><a href="automate-contractor-business.html" style="color: inherit; text-decoration: none;">Construction Management</a></h3>
                         <p>From high-end residential renovations near Dunwoody Country Club to commercial buildouts in Perimeter Center, general contractors need robust project management systems to coordinate complex builds.</p>
                     </div>
                 </div>

--- a/automate-business-johns-creek-ga.html
+++ b/automate-business-johns-creek-ga.html
@@ -325,25 +325,25 @@
                 <div class="services-grid">
                     <div class="service-card">
                         <div class="service-icon">🏠</div>
-                        <h3>Luxury HVAC Services</h3>
+                        <h3><a href="automate-hvac-business.html" style="color: inherit; text-decoration: none;">Luxury HVAC Services</a></h3>
                         <p>Serving high-end residential properties from Country Club of the South to Newtown Park requires sophisticated customer management systems that match the premium expectations of Johns Creek homeowners.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">⚡</div>
-                        <h3>Smart Home Electrical</h3>
+                        <h3><a href="automate-electrical-business.html" style="color: inherit; text-decoration: none;">Smart Home Electrical</a></h3>
                         <p>Johns Creek's tech-savvy residents demand cutting-edge electrical solutions and home automation. Our systems help electrical contractors manage complex smart home projects and maintain detailed technical documentation.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🔧</div>
-                        <h3>Premium Plumbing</h3>
+                        <h3><a href="automate-plumbing-business.html" style="color: inherit; text-decoration: none;">Premium Plumbing</a></h3>
                         <p>From luxury bathroom renovations to commercial projects near Technology Park, plumbing contractors need efficient scheduling and customer communication systems to serve Johns Creek's demanding market.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🏗️</div>
-                        <h3>Custom Construction</h3>
+                        <h3><a href="automate-contractor-business.html" style="color: inherit; text-decoration: none;">Custom Construction</a></h3>
                         <p>Managing custom homes and high-end renovations throughout Johns Creek's established neighborhoods requires sophisticated project management and client communication systems.</p>
                     </div>
                 </div>

--- a/automate-business-kennesaw-ga.html
+++ b/automate-business-kennesaw-ga.html
@@ -325,25 +325,25 @@
                 <div class="services-grid">
                     <div class="service-card">
                         <div class="service-icon">🏠</div>
-                        <h3>Residential HVAC</h3>
+                        <h3><a href="automate-hvac-business.html" style="color: inherit; text-decoration: none;">Residential HVAC</a></h3>
                         <p>Serving everything from student housing complexes near KSU to luxury homes in established neighborhoods like Swift-Cantrell Park area. Our automation handles seasonal demand spikes and emergency calls across Kennesaw's diverse residential landscape.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">⚡</div>
-                        <h3>Electrical Services</h3>
+                        <h3><a href="automate-electrical-business.html" style="color: inherit; text-decoration: none;">Electrical Services</a></h3>
                         <p>Managing electrical projects from historic downtown Kennesaw buildings to modern university facilities and new commercial developments along Barrett Parkway requires sophisticated scheduling and project coordination systems.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🔧</div>
-                        <h3>Plumbing Operations</h3>
+                        <h3><a href="automate-plumbing-business.html" style="color: inherit; text-decoration: none;">Plumbing Operations</a></h3>
                         <p>Handling both emergency calls in older residential areas near Kennesaw Mountain and new construction projects throughout Cobb County requires automated dispatch and efficient inventory management to maintain response times.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🏗️</div>
-                        <h3>Construction Management</h3>
+                        <h3><a href="automate-contractor-business.html" style="color: inherit; text-decoration: none;">Construction Management</a></h3>
                         <p>From historic preservation projects in downtown Kennesaw to new residential developments and university facility work, general contractors need robust systems to coordinate multiple trades and maintain quality standards.</p>
                     </div>
                 </div>

--- a/automate-business-marietta-ga.html
+++ b/automate-business-marietta-ga.html
@@ -152,13 +152,13 @@
                 <div class="services-grid">
                     <div class="service-card">
                         <div class="service-icon">🔧</div>
-                        <h3>HVAC Business Automation</h3>
+                        <h3><a href="automate-hvac-business.html" style="color: inherit; text-decoration: none;">HVAC Business Automation</a></h3>
                         <p>Marietta's diverse housing stock, from historic homes near the square to new construction in subdivisions like Powder Springs and due West, requires HVAC contractors to manage complex scheduling and service needs. Our automation solutions help HVAC companies streamline emergency calls, preventive maintenance scheduling, and seasonal surge management.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">⚡</div>
-                        <h3>Electrical Contractor Solutions</h3>
+                        <h3><a href="automate-electrical-business.html" style="color: inherit; text-decoration: none;">Electrical Contractor Solutions</a></h3>
                         <p>With major commercial developments along Roswell Road and new residential projects throughout Marietta, electrical contractors need sophisticated project management and permit tracking systems. We automate estimate generation, permit status monitoring, and material ordering to keep projects on schedule and profitable.</p>
                     </div>
                     

--- a/automate-business-powder-springs-ga.html
+++ b/automate-business-powder-springs-ga.html
@@ -325,25 +325,25 @@
                 <div class="services-grid">
                     <div class="service-card">
                         <div class="service-icon">🏠</div>
-                        <h3>Residential HVAC</h3>
+                        <h3><a href="automate-hvac-business.html" style="color: inherit; text-decoration: none;">Residential HVAC</a></h3>
                         <p>From established neighborhoods near Powder Springs Park to newer developments along the Silver Comet Trail corridor, HVAC contractors need efficient scheduling systems to serve diverse housing types and maintain optimal comfort in this family-oriented community.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">⚡</div>
-                        <h3>Electrical Services</h3>
+                        <h3><a href="automate-electrical-business.html" style="color: inherit; text-decoration: none;">Electrical Services</a></h3>
                         <p>Managing electrical projects across Powder Springs' mix of historic downtown buildings, established residential areas, and modern commercial developments requires sophisticated coordination and customer communication systems.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🔧</div>
-                        <h3>Plumbing Operations</h3>
+                        <h3><a href="automate-plumbing-business.html" style="color: inherit; text-decoration: none;">Plumbing Operations</a></h3>
                         <p>Serving both emergency calls and maintenance requests throughout Cobb County's western communities requires automated dispatch systems and efficient inventory management to maintain quick response times and customer satisfaction.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🏗️</div>
-                        <h3>Construction Management</h3>
+                        <h3><a href="automate-contractor-business.html" style="color: inherit; text-decoration: none;">Construction Management</a></h3>
                         <p>From downtown revitalization projects to residential renovations and new commercial construction along Highway 278, contractors need robust project management systems to coordinate trades and maintain quality standards.</p>
                     </div>
                 </div>

--- a/automate-business-roswell-ga.html
+++ b/automate-business-roswell-ga.html
@@ -325,25 +325,25 @@
                 <div class="services-grid">
                     <div class="service-card">
                         <div class="service-icon">🏠</div>
-                        <h3>Historic Home HVAC</h3>
+                        <h3><a href="automate-hvac-business.html" style="color: inherit; text-decoration: none;">Historic Home HVAC</a></h3>
                         <p>Managing HVAC systems in Roswell's historic properties requires specialized knowledge and careful coordination. Our automation helps schedule maintenance, track system modifications, and maintain detailed service records for heritage properties.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">⚡</div>
-                        <h3>Electrical Upgrades</h3>
+                        <h3><a href="automate-electrical-business.html" style="color: inherit; text-decoration: none;">Electrical Upgrades</a></h3>
                         <p>From modernizing electrical systems in historic homes to installing smart home technology in luxury developments, Roswell electrical contractors need sophisticated project management and customer communication capabilities.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🔧</div>
-                        <h3>Premium Plumbing</h3>
+                        <h3><a href="automate-plumbing-business.html" style="color: inherit; text-decoration: none;">Premium Plumbing</a></h3>
                         <p>Serving both historic preservation projects and luxury new construction requires flexible systems that handle emergency calls and scheduled upgrades with equal professionalism and efficiency.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🏗️</div>
-                        <h3>Construction Management</h3>
+                        <h3><a href="automate-contractor-business.html" style="color: inherit; text-decoration: none;">Construction Management</a></h3>
                         <p>Managing projects from Riverside Park area renovations to new construction near the Chattahoochee requires coordination tools that ensure quality delivery and customer satisfaction.</p>
                     </div>
                 </div>

--- a/automate-business-sandy-springs-ga.html
+++ b/automate-business-sandy-springs-ga.html
@@ -127,25 +127,25 @@
                 <div class="services-grid">
                     <div class="service-card">
                         <div class="service-icon">🏢</div>
-                        <h3>Corporate HVAC Services</h3>
+                        <h3><a href="automate-hvac-business.html" style="color: inherit; text-decoration: none;">Corporate HVAC Services</a></h3>
                         <p>Managing HVAC systems for Perimeter Center office towers and luxury residential properties requires sophisticated scheduling, predictive maintenance, and enterprise-level documentation capabilities.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">⚡</div>
-                        <h3>Executive Electrical Solutions</h3>
+                        <h3><a href="automate-electrical-business.html" style="color: inherit; text-decoration: none;">Executive Electrical Solutions</a></h3>
                         <p>From smart building installations in corporate facilities to luxury home automation systems, Sandy Springs electrical contractors need advanced project management and client communication tools.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">💎</div>
-                        <h3>Luxury Plumbing Operations</h3>
+                        <h3><a href="automate-plumbing-business.html" style="color: inherit; text-decoration: none;">Luxury Plumbing Operations</a></h3>
                         <p>Serving high-end residential communities and commercial facilities requires premium service delivery, VIP customer management, and sophisticated parts procurement systems.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🏗️</div>
-                        <h3>Enterprise Construction</h3>
+                        <h3><a href="automate-contractor-business.html" style="color: inherit; text-decoration: none;">Enterprise Construction</a></h3>
                         <p>Managing projects for corporate clients and luxury developments demands enterprise-grade project coordination, compliance tracking, and real-time reporting capabilities.</p>
                     </div>
                 </div>

--- a/automate-business-smyrna-ga.html
+++ b/automate-business-smyrna-ga.html
@@ -327,25 +327,25 @@
                 <div class="services-grid">
                     <div class="service-card">
                         <div class="service-icon">🏠</div>
-                        <h3>HVAC Services</h3>
+                        <h3><a href="automate-hvac-business.html" style="color: inherit; text-decoration: none;">HVAC Services</a></h3>
                         <p>Managing HVAC services across Smyrna's diverse housing stock, from older homes near Jonquil Park to modern condominiums in Vinings, requires efficient scheduling systems and automated customer communication to handle seasonal demand spikes and emergency calls.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">⚡</div>
-                        <h3>Electrical Operations</h3>
+                        <h3><a href="automate-electrical-business.html" style="color: inherit; text-decoration: none;">Electrical Operations</a></h3>
                         <p>Electrical contractors serving the Cumberland business district, residential neighborhoods, and new developments around SunTrust Park need sophisticated project management systems to coordinate complex commercial installations and residential service calls.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🔧</div>
-                        <h3>Plumbing Management</h3>
+                        <h3><a href="automate-plumbing-business.html" style="color: inherit; text-decoration: none;">Plumbing Management</a></h3>
                         <p>From emergency plumbing calls in established neighborhoods to new construction projects in developing areas, Smyrna plumbing contractors benefit from automated dispatch systems and inventory management to maintain rapid response times across the service area.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🏗️</div>
-                        <h3>Construction Coordination</h3>
+                        <h3><a href="automate-contractor-business.html" style="color: inherit; text-decoration: none;">Construction Coordination</a></h3>
                         <p>General contractors working on everything from downtown Smyrna revitalization projects to residential developments near the Silver Comet Trail need robust project management automation to coordinate multiple trades and maintain quality standards.</p>
                     </div>
                 </div>

--- a/automate-business-vinings-ga.html
+++ b/automate-business-vinings-ga.html
@@ -327,25 +327,25 @@
                 <div class="services-grid">
                     <div class="service-card">
                         <div class="service-icon">🏠</div>
-                        <h3>Premium HVAC Services</h3>
+                        <h3><a href="automate-hvac-business.html" style="color: inherit; text-decoration: none;">Premium HVAC Services</a></h3>
                         <p>Servicing luxury homes from Paces Ferry Road to the Riverfront community requires advanced scheduling systems to coordinate maintenance on high-end equipment while managing emergency calls for discerning homeowners who expect immediate response.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">⚡</div>
-                        <h3>Electrical Specialization</h3>
+                        <h3><a href="automate-electrical-business.html" style="color: inherit; text-decoration: none;">Electrical Specialization</a></h3>
                         <p>From smart home installations in Vinings' upscale neighborhoods to commercial electrical work near Cumberland Mall and Vinings Jubilee, contractors need sophisticated project management to handle complex installations and maintain quality standards.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🔧</div>
-                        <h3>Luxury Plumbing Systems</h3>
+                        <h3><a href="automate-plumbing-business.html" style="color: inherit; text-decoration: none;">Luxury Plumbing Systems</a></h3>
                         <p>Managing installations and service calls for premium fixtures and complex plumbing systems in Vinings' high-value homes requires automated inventory management and detailed customer communication systems to maintain service excellence.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🏗️</div>
-                        <h3>Custom Construction</h3>
+                        <h3><a href="automate-contractor-business.html" style="color: inherit; text-decoration: none;">Custom Construction</a></h3>
                         <p>From kitchen renovations in historic Vinings homes to new construction near the Chattahoochee River, general contractors need robust project coordination systems to manage multiple trades and maintain the quality expectations of affluent clients.</p>
                     </div>
                 </div>

--- a/automate-business-woodstock-ga.html
+++ b/automate-business-woodstock-ga.html
@@ -325,25 +325,25 @@
                 <div class="services-grid">
                     <div class="service-card">
                         <div class="service-icon">🏠</div>
-                        <h3>Residential HVAC</h3>
+                        <h3><a href="automate-hvac-business.html" style="color: inherit; text-decoration: none;">Residential HVAC</a></h3>
                         <p>From established neighborhoods near downtown Woodstock to new developments in the Towne Lake area, HVAC contractors need efficient scheduling and customer management systems to handle the area's rapid residential growth.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">⚡</div>
-                        <h3>Electrical Services</h3>
+                        <h3><a href="automate-electrical-business.html" style="color: inherit; text-decoration: none;">Electrical Services</a></h3>
                         <p>Managing electrical projects across Woodstock's diverse areas, from historic downtown buildings to modern residential and commercial developments, requires sophisticated project coordination and customer communication.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🔧</div>
-                        <h3>Plumbing Operations</h3>
+                        <h3><a href="automate-plumbing-business.html" style="color: inherit; text-decoration: none;">Plumbing Operations</a></h3>
                         <p>Serving both emergency calls and new construction projects throughout Cherokee County requires automated dispatch systems and efficient parts management to maintain response times and profitability.</p>
                     </div>
                     
                     <div class="service-card">
                         <div class="service-icon">🏗️</div>
-                        <h3>Construction Management</h3>
+                        <h3><a href="automate-contractor-business.html" style="color: inherit; text-decoration: none;">Construction Management</a></h3>
                         <p>From downtown revitalization projects to new residential developments, general contractors need robust project management systems to coordinate trades and maintain quality standards.</p>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -704,7 +704,7 @@
                             </defs>
                         </svg>
                     </div>
-                    <h3 itemprop="name">Project Management Automation</h3>
+                    <h3 itemprop="name"><a href="/project-management-automation/" style="color: inherit; text-decoration: none;">Project Management Automation</a></h3>
                     <p itemprop="description">Streamline project workflows, coordinate trades, track progress, and manage timelines with automated project management systems designed for contractors. Integrates seamlessly with <a href="/accounting-automation/" style="color: #475569; text-decoration: none;">accounting automation</a> for complete project profitability tracking.</p>
                     <a href="/project-management-automation/" class="service-link">Learn More →</a>
                 </div>
@@ -789,7 +789,7 @@
                             </defs>
                         </svg>
                     </div>
-                    <h3 itemprop="name">Business Process & Task Automation</h3>
+                    <h3 itemprop="name"><a href="/business-process-automation/" style="color: inherit; text-decoration: none;">Business Process & Task Automation</a></h3>
                     <p itemprop="description">Eliminate repetitive tasks with custom workflows that handle scheduling, dispatching, customer communication, and administrative work automatically.</p>
                     <a href="/business-process-automation/" class="service-link">Learn More →</a>
                 </div>
@@ -885,7 +885,7 @@
                             </defs>
                         </svg>
                     </div>
-                    <h3 itemprop="name">Accounting Automation</h3>
+                    <h3 itemprop="name"><a href="/accounting-automation/" style="color: inherit; text-decoration: none;">Accounting Automation</a></h3>
                     <p itemprop="description">Automate invoicing, expense tracking, payment processing, and financial reporting with seamless <a href="/quickbooks-automation/" style="color: #475569; text-decoration: none;">QuickBooks integration</a> and custom accounting workflows.</p>
                     <a href="/accounting-automation/" class="service-link">Learn More →</a>
                 </div>
@@ -996,7 +996,7 @@
                             </defs>
                         </svg>
                     </div>
-                    <h3 itemprop="name">Lead Generation & Follow-Up Automation</h3>
+                    <h3 itemprop="name"><a href="/lead-generation-automation/" style="color: inherit; text-decoration: none;">Lead Generation & Follow-Up Automation</a></h3>
                     <p itemprop="description">Never miss another lead with automated capture, qualification, nurturing sequences, and follow-up systems that convert prospects into customers faster. Works perfectly with <a href="/business-process-automation/" style="color: #475569; text-decoration: none;">process automation</a> to handle the entire customer journey.</p>
                     <a href="/lead-generation-automation/" class="service-link">Learn More →</a>
                 </div>
@@ -1124,7 +1124,7 @@
                             </defs>
                         </svg>
                     </div>
-                    <h3 itemprop="name">AI Integration & Smart Systems</h3>
+                    <h3 itemprop="name"><a href="/ai-integration-automation/" style="color: inherit; text-decoration: none;">AI Integration & Smart Systems</a></h3>
                     <p itemprop="description">Leverage cutting-edge AI for predictive scheduling, intelligent pricing, automated customer service, and smart decision-making systems.</p>
                     <a href="/ai-integration-automation/" class="service-link">Learn More →</a>
                 </div>


### PR DESCRIPTION
## Summary
- Link homepage service-card headings to their detailed service pages
- Link service cards on city pages to relevant service pages
- Add "Serving Nearby Cities" section on Alpharetta page linking to Roswell, Johns Creek, and Sandy Springs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d858a7e48323bdc46580062700d4