### PR TITLE
Use image-only logo on service pages

### DIFF
--- a/accounting-automation.html
+++ b/accounting-automation.html
@@ -100,7 +100,8 @@
         /* Header - Match index.html exactly */
         header { background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); border-bottom: 1px solid #e5e7eb; position: fixed; top: 0; width: 100%; z-index: 100; transition: all 0.3s ease; }
         nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 0; }
-        .logo { font-size: 1.5rem; font-weight: 700; color: #1f2937; text-decoration: none; }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         .nav-links { display: flex; list-style: none; gap: 2rem; }
         .nav-links a { text-decoration: none; color: #4b5563; font-weight: 500; transition: color 0.3s ease; }
         .nav-links a:hover { color: #2563eb; }
@@ -190,7 +191,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/ai-integration-automation.html
+++ b/ai-integration-automation.html
@@ -96,7 +96,8 @@
         /* Header - Match index.html exactly */
         header { background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); border-bottom: 1px solid #e5e7eb; position: fixed; top: 0; width: 100%; z-index: 100; transition: all 0.3s ease; }
         nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 0; }
-        .logo { font-size: 1.5rem; font-weight: 700; color: #1f2937; text-decoration: none; }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         .nav-links { display: flex; list-style: none; gap: 2rem; }
         .nav-links a { text-decoration: none; color: #4b5563; font-weight: 500; transition: color 0.3s ease; }
         .nav-links a:hover { color: #2563eb; }
@@ -193,7 +194,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/automate-business-acworth-ga.html
+++ b/automate-business-acworth-ga.html
@@ -37,7 +37,8 @@
         .container { max-width: 1200px; margin: 0 auto; padding: 0 20px; }
         header { background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); border-bottom: 1px solid #e5e7eb; position: fixed; top: 0; width: 100%; z-index: 100; }
         nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 0; }
-        .logo { font-size: 1.5rem; font-weight: 700; color: #1f2937; text-decoration: none; }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         .nav-links { display: flex; list-style: none; gap: 2rem; }
         .nav-links a { text-decoration: none; color: #4b5563; font-weight: 500; transition: color 0.3s ease; }
         .nav-links a:hover { color: #2563eb; }
@@ -70,7 +71,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/automate-business-alpharetta-ga.html
+++ b/automate-business-alpharetta-ga.html
@@ -69,12 +69,8 @@
             padding: 1rem 0;
         }
         
-        .logo {
-            font-size: 1.5rem;
-            font-weight: 700;
-            color: #1f2937;
-            text-decoration: none;
-        }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         
         .nav-links {
             display: flex;
@@ -296,7 +292,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/automate-business-dunwoody-ga.html
+++ b/automate-business-dunwoody-ga.html
@@ -69,12 +69,8 @@
             padding: 1rem 0;
         }
         
-        .logo {
-            font-size: 1.5rem;
-            font-weight: 700;
-            color: #1f2937;
-            text-decoration: none;
-        }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         
         .nav-links {
             display: flex;
@@ -268,7 +264,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/automate-business-johns-creek-ga.html
+++ b/automate-business-johns-creek-ga.html
@@ -69,12 +69,8 @@
             padding: 1rem 0;
         }
         
-        .logo {
-            font-size: 1.5rem;
-            font-weight: 700;
-            color: #1f2937;
-            text-decoration: none;
-        }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         
         .nav-links {
             display: flex;
@@ -268,7 +264,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/automate-business-kennesaw-ga.html
+++ b/automate-business-kennesaw-ga.html
@@ -69,12 +69,8 @@
             padding: 1rem 0;
         }
         
-        .logo {
-            font-size: 1.5rem;
-            font-weight: 700;
-            color: #1f2937;
-            text-decoration: none;
-        }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         
         .nav-links {
             display: flex;
@@ -268,7 +264,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/automate-business-marietta-ga.html
+++ b/automate-business-marietta-ga.html
@@ -54,7 +54,8 @@
         
         header { background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); border-bottom: 1px solid #e5e7eb; position: fixed; top: 0; width: 100%; z-index: 100; }
         nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 0; }
-        .logo { font-size: 1.5rem; font-weight: 700; color: #1f2937; text-decoration: none; }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         .nav-links { display: flex; list-style: none; gap: 2rem; }
         .nav-links a { text-decoration: none; color: #4b5563; font-weight: 500; transition: color 0.3s ease; }
         .nav-links a:hover { color: #2563eb; }
@@ -94,7 +95,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="index.html" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="index.html#services">Services</a></li>
                 <li><a href="index.html#industries">Industries</a></li>

--- a/automate-business-powder-springs-ga.html
+++ b/automate-business-powder-springs-ga.html
@@ -69,12 +69,8 @@
             padding: 1rem 0;
         }
         
-        .logo {
-            font-size: 1.5rem;
-            font-weight: 700;
-            color: #1f2937;
-            text-decoration: none;
-        }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         
         .nav-links {
             display: flex;
@@ -268,7 +264,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/automate-business-roswell-ga.html
+++ b/automate-business-roswell-ga.html
@@ -69,12 +69,8 @@
             padding: 1rem 0;
         }
         
-        .logo {
-            font-size: 1.5rem;
-            font-weight: 700;
-            color: #1f2937;
-            text-decoration: none;
-        }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         
         .nav-links {
             display: flex;
@@ -268,7 +264,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/automate-business-sandy-springs-ga.html
+++ b/automate-business-sandy-springs-ga.html
@@ -37,7 +37,8 @@
         .container { max-width: 1200px; margin: 0 auto; padding: 0 20px; }
         header { background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); border-bottom: 1px solid #e5e7eb; position: fixed; top: 0; width: 100%; z-index: 100; }
         nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 0; }
-        .logo { font-size: 1.5rem; font-weight: 700; color: #1f2937; text-decoration: none; }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         .nav-links { display: flex; list-style: none; gap: 2rem; }
         .nav-links a { text-decoration: none; color: #4b5563; font-weight: 500; transition: color 0.3s ease; }
         .nav-links a:hover { color: #2563eb; }
@@ -70,7 +71,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/automate-business-smyrna-ga.html
+++ b/automate-business-smyrna-ga.html
@@ -69,12 +69,8 @@
             padding: 1rem 0;
         }
         
-        .logo {
-            font-size: 1.5rem;
-            font-weight: 700;
-            color: #1f2937;
-            text-decoration: none;
-        }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         
         .nav-links {
             display: flex;
@@ -268,7 +264,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/automate-business-vinings-ga.html
+++ b/automate-business-vinings-ga.html
@@ -69,12 +69,8 @@
             padding: 1rem 0;
         }
         
-        .logo {
-            font-size: 1.5rem;
-            font-weight: 700;
-            color: #1f2937;
-            text-decoration: none;
-        }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         
         .nav-links {
             display: flex;
@@ -268,7 +264,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/automate-business-woodstock-ga.html
+++ b/automate-business-woodstock-ga.html
@@ -69,12 +69,8 @@
             padding: 1rem 0;
         }
         
-        .logo {
-            font-size: 8rem;
-            font-weight: 700;
-            color: #1f2937;
-            text-decoration: none;
-        }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         
         .nav-links {
             display: flex;
@@ -268,7 +264,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/automate-contractor-business.html
+++ b/automate-contractor-business.html
@@ -100,7 +100,8 @@
         /* Header - Match index.html exactly */
         header { background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); border-bottom: 1px solid #e5e7eb; position: fixed; top: 0; width: 100%; z-index: 100; transition: all 0.3s ease; }
         nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 0; }
-        .logo { font-size: 1.5rem; font-weight: 700; color: #1f2937; text-decoration: none; }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         .nav-links { display: flex; list-style: none; gap: 2rem; }
         .nav-links a { text-decoration: none; color: #4b5563; font-weight: 500; transition: color 0.3s ease; }
         .nav-links a:hover { color: #2563eb; }
@@ -226,7 +227,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/automate-electrical-business.html
+++ b/automate-electrical-business.html
@@ -100,7 +100,8 @@
         /* Header - Match index.html exactly */
         header { background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); border-bottom: 1px solid #e5e7eb; position: fixed; top: 0; width: 100%; z-index: 100; transition: all 0.3s ease; }
         nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 0; }
-        .logo { font-size: 1.5rem; font-weight: 700; color: #1f2937; text-decoration: none; }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         .nav-links { display: flex; list-style: none; gap: 2rem; }
         .nav-links a { text-decoration: none; color: #4b5563; font-weight: 500; transition: color 0.3s ease; }
         .nav-links a:hover { color: #2563eb; }
@@ -206,7 +207,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/automate-hvac-business.html
+++ b/automate-hvac-business.html
@@ -131,12 +131,8 @@
             padding: 1rem 0;
         }
         
-        .logo {
-            font-size: 1.5rem;
-            font-weight: 700;
-            color: #1f2937;
-            text-decoration: none;
-        }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         
         .nav-links {
             display: flex;
@@ -745,7 +741,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/automate-lawn-care-business.html
+++ b/automate-lawn-care-business.html
@@ -100,7 +100,8 @@
         /* Header - Match index.html exactly */
         header { background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); border-bottom: 1px solid #e5e7eb; position: fixed; top: 0; width: 100%; z-index: 100; transition: all 0.3s ease; }
         nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 0; }
-        .logo { font-size: 1.5rem; font-weight: 700; color: #1f2937; text-decoration: none; }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         .nav-links { display: flex; list-style: none; gap: 2rem; }
         .nav-links a { text-decoration: none; color: #4b5563; font-weight: 500; transition: color 0.3s ease; }
         .nav-links a:hover { color: #2563eb; }
@@ -226,7 +227,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/automate-plumbing-business.html
+++ b/automate-plumbing-business.html
@@ -100,7 +100,8 @@
         /* Header - Match index.html exactly */
         header { background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); border-bottom: 1px solid #e5e7eb; position: fixed; top: 0; width: 100%; z-index: 100; transition: all 0.3s ease; }
         nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 0; }
-        .logo { font-size: 1.5rem; font-weight: 700; color: #1f2937; text-decoration: none; }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         .nav-links { display: flex; list-style: none; gap: 2rem; }
         .nav-links a { text-decoration: none; color: #4b5563; font-weight: 500; transition: color 0.3s ease; }
         .nav-links a:hover { color: #2563eb; }
@@ -206,7 +207,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/business-process-automation.html
+++ b/business-process-automation.html
@@ -96,7 +96,8 @@
         /* Header - Match index.html exactly */
         header { background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); border-bottom: 1px solid #e5e7eb; position: fixed; top: 0; width: 100%; z-index: 100; transition: all 0.3s ease; }
         nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 0; }
-        .logo { font-size: 1.5rem; font-weight: 700; color: #1f2937; text-decoration: none; }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         .nav-links { display: flex; list-style: none; gap: 2rem; }
         .nav-links a { text-decoration: none; color: #4b5563; font-weight: 500; transition: color 0.3s ease; }
         .nav-links a:hover { color: #2563eb; }
@@ -179,7 +180,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/lead-generation-automation.html
+++ b/lead-generation-automation.html
@@ -96,7 +96,8 @@
         /* Header - Match index.html exactly */
         header { background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); border-bottom: 1px solid #e5e7eb; position: fixed; top: 0; width: 100%; z-index: 100; transition: all 0.3s ease; }
         nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 0; }
-        .logo { font-size: 1.5rem; font-weight: 700; color: #1f2937; text-decoration: none; }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         .nav-links { display: flex; list-style: none; gap: 2rem; }
         .nav-links a { text-decoration: none; color: #4b5563; font-weight: 500; transition: color 0.3s ease; }
         .nav-links a:hover { color: #2563eb; }
@@ -190,7 +191,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/project-management-automation.html
+++ b/project-management-automation.html
@@ -88,7 +88,8 @@
         /* Header - Match index.html exactly */
         header { background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); border-bottom: 1px solid #e5e7eb; position: fixed; top: 0; width: 100%; z-index: 100; transition: all 0.3s ease; }
         nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 0; }
-        .logo { font-size: 1.5rem; font-weight: 700; color: #1f2937; text-decoration: none; }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         .nav-links { display: flex; list-style: none; gap: 2rem; }
         .nav-links a { text-decoration: none; color: #4b5563; font-weight: 500; transition: color 0.3s ease; }
         .nav-links a:hover { color: #2563eb; }
@@ -168,7 +169,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/quickbooks-automation.html
+++ b/quickbooks-automation.html
@@ -100,7 +100,8 @@
         /* Header - Match index.html exactly */
         header { background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); border-bottom: 1px solid #e5e7eb; position: fixed; top: 0; width: 100%; z-index: 100; transition: all 0.3s ease; }
         nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 0; }
-        .logo { font-size: 1.5rem; font-weight: 700; color: #1f2937; text-decoration: none; }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         .nav-links { display: flex; list-style: none; gap: 2rem; }
         .nav-links a { text-decoration: none; color: #4b5563; font-weight: 500; transition: color 0.3s ease; }
         .nav-links a:hover { color: #2563eb; }
@@ -210,7 +211,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/service-areas.html
+++ b/service-areas.html
@@ -47,12 +47,8 @@
             padding: 1rem 0;
         }
         
-        .logo {
-            font-size: 1.5rem;
-            font-weight: 700;
-            color: #1f2937;
-            text-decoration: none;
-        }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         
         .nav-links {
             display: flex;
@@ -234,7 +230,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="/" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="/#services">Services</a></li>
                 <li><a href="/#industries">Industries</a></li>

--- a/services.html
+++ b/services.html
@@ -86,7 +86,8 @@
         
         header { background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px); border-bottom: 1px solid #e5e7eb; position: fixed; top: 0; width: 100%; z-index: 100; }
         nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 0; }
-        .logo { font-size: 1.5rem; font-weight: 700; color: #1f2937; text-decoration: none; }
+        .logo { display: inline-block; }
+        .logo img { height: 8rem; width: auto; }
         .nav-links { display: flex; list-style: none; gap: 2rem; }
         .nav-links a { text-decoration: none; color: #4b5563; font-weight: 500; transition: color 0.3s ease; }
         .nav-links a:hover { color: #2563eb; }
@@ -131,7 +132,7 @@
 <body>
     <header>
         <nav class="container">
-            <a href="index.html" class="logo">Fortress 5 Consulting</a>
+            <a href="/" class="logo"><img src="/Fortress+master+logo.png" alt="Fortress 5 Consulting"></a>
             <ul class="nav-links">
                 <li><a href="index.html">Home</a></li>
                 <li><a href="services.html">Services</a></li>


### PR DESCRIPTION
## Summary
- Display only the company logo (no text) in page headers
- Set logo images to 8rem height with auto width across service and service-area pages

## Testing
- `npx --yes htmlhint services.html` *(fails: Special characters must be escaped)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d1e070e48323a41a1f8e6c78e5e7